### PR TITLE
Adds Dart support

### DIFF
--- a/CoverMe.py
+++ b/CoverMe.py
@@ -67,8 +67,17 @@ class CoverMe(sublime_plugin.TextCommand):
 			return 
 		erase_coverage(self.view)
 		self.current_mode = self.cover_modes[arg]
+		filename = self.view.file_name()
 		if 'basepath' not in self.current_mode:
-			self.current_mode['basepath'] = os.path.dirname(self.view.file_name())
+			if "project" not in self.current_mode or not self.current_mode["project"]:
+				self.current_mode['basepath'] = os.path.dirname(self.view.file_name())
+			else:
+				for entry in self.view.window().project_data()["folders"]:
+					folder = entry["path"]
+					if folder in filename:
+						self.current_mode["basepath"] = folder
+						break
+		self.set_status("Running command in " + self.current_mode["basepath"])
 		# Start test running on a non blocking thread.
 		thread = threading.Thread(target = self.run_tests)
 		thread.start()

--- a/CoverMe.sublime-settings
+++ b/CoverMe.sublime-settings
@@ -3,7 +3,8 @@
 	// This parameter matches the cover object to its respective extension.
 	"matching" : {
 		"go" : "go",
-		"python" : "py"
+		"python" : "py",
+		"dart": "dart",
 	},
 
 	// Global variables required by the cover object.
@@ -14,5 +15,8 @@
 	},
 	"python" : {
 	
+	},
+	"dart": { 
+
 	}
 }

--- a/CoverMeModes.sublime-settings
+++ b/CoverMeModes.sublime-settings
@@ -21,5 +21,13 @@
 				"coverage report -m"
 			]
 		}
+	],
+	"dart": [
+		{
+			"title": "Cover all",
+			"commands": [
+				"dart test --coverage=test/coverage"
+			]
+		}
 	]
 }

--- a/CoverMeModes.sublime-settings
+++ b/CoverMeModes.sublime-settings
@@ -24,7 +24,8 @@
 	],
 	"dart": [
 		{
-			"title": "Cover all",
+			"title": "Cover project",
+			"project": true,
 			"commands": [
 				"dart test --coverage=test/coverage"
 			]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This plugin can easily be extended for any testing framework for any programming
 #### Prograaming languages supported
 - Go's `go test`
 - Python's `unittest` and `coverage.py`
+- Dart's `dart test`
 
 The basic paradigm followed by the plugin is:
 - Run the commands necessary to generate coverage output.

--- a/lang/dart.py
+++ b/lang/dart.py
@@ -9,6 +9,7 @@ def resolve_uri(uri, package_dir):
 	"""
 	file = uri [uri.find("/") + 1:]
 	path = package_dir + "\\lib\\" + file.replace("/", "\\")	
+	return path
 
 def parse_coverage_file(current_mode, stdoutput): 
 	# Assumes tests were run with:

--- a/lang/dart.py
+++ b/lang/dart.py
@@ -1,0 +1,65 @@
+import os
+import json
+
+def resolve_uri(uri, package_dir):
+	"""
+	Given package:project/path/to/file.dart, returns:
+	C:\\path\\to\\project\\lib\\path\\to\\file.dart
+	(Windows only)
+	"""
+	file = uri [uri.find("/") + 1:]
+	path = package_dir + "\\lib\\" + file.replace("/", "\\")	
+
+def parse_coverage_file(current_mode, stdoutput): 
+	# Assumes tests were run with:
+	# dart test --coverage=test/coverage
+	package_dir = current_mode["basepath"]
+	package_name = package_dir.split("\\") [-1]
+	coverage_dir = package_dir + "\\test\\coverage\\test"
+	coverage_files = os.listdir(coverage_dir)
+
+	# Data is returned in JSON files.
+	# Each file contains JSON objects, one for each file
+	# Each file has: 
+	# - "source": URI of the file (see below)
+	# - "hits": list of numbers
+	# 
+	# Dart URIs are of the form: package:project/path/to/file.dart
+	# We need to resolve it into a full-fledged file path.
+	# We use the variables set above to do so.
+	# 
+	# "hits" is one-dimensional, but it's actually arranged in pairs.
+	# Each pair is (line_number, times_line_was_run)
+	# CoverMe doesn't need the latter, so we filter it out.
+
+	result = {}
+	for cov_file in coverage_files:
+		# Load the file
+		filename = coverage_dir + "\\" + cov_file
+		with open(filename) as file: 
+			contents = json.load(file)
+
+		# Read the JSON file
+		for entry in contents ["coverage"]:
+			# There are many irrelevant files in the coverage report. 
+			if ("package:" + package_name) not in entry["source"]: continue
+
+			uri = entry["source"]
+			hits = entry["hits"]
+			path = resolve_uri(uri, package_dir)
+			if path not in result: result[path] = []
+
+			# Line numbers are every *other* element
+			for index in range(0, len(hits), 2):  
+				line = hits[index]
+				if line not in result[path]: result[path].append(line)
+
+	# CoverMe expects to have line *ranges*, but we only have line numbers
+	return {
+		file: [
+			(line, line + 1) for line in result[file]
+		]
+		for file in result
+	}
+
+	return result


### PR DESCRIPTION
My solution to #1 (it's not a generalized solution, I just figured out how to add Dart).

Note: I added a field `project` to `CoverMeModes.sublime-settings`, because some languages/environments need the test command to be run in the root of the _project_, but currently `basepath` is set to use the path of the file instead. I don't know how that affects Python and Go, so I just made the `project` field optional and only used it on Dart. 

As an example: if you have this file structure: 

```
my-coding-folder
|- my-project
   |- tests
      |- test_1.dart
      |- test_2.dart
   |- lib
      |- main.dart
      |- data.dart
```

Currently, when running CoverMe on `man.dart`, `basepath` was set to `my-coding-folder/my-project/lib/main.dart`, but Dart really wants the command to be run in `my-coding-folder/my-project`. 

Of course, every language has their own idea of what is a "package", so instead of using Dart-specific code, I simply check which folder in the Sublime project contains the path of the current file. In my case, I'd have `my-coding-folder/my-project` added to Sublime, so that would be chosen as the project folder. And of course, if someone uses the `basepath` option in their `.sublime-project` file, they would have complete control over this manually. 